### PR TITLE
Fix Deprecation warning when using CakePHP 3.9

### DIFF
--- a/src/Controller/Component/InvisibleReCaptchaComponent.php
+++ b/src/Controller/Component/InvisibleReCaptchaComponent.php
@@ -66,6 +66,6 @@ class InvisibleReCaptchaComponent extends Component
             'remoteip' => $request->clientIp(),
         ]);
 
-        return $response->json;
+        return $response->getJson();
     }
 }


### PR DESCRIPTION
I have replaced $response->json with $response->getJson() to avoid deprecation warnings.